### PR TITLE
Make status nudge configurable per device

### DIFF
--- a/custom_components/philips_airpurifier/__init__.py
+++ b/custom_components/philips_airpurifier/__init__.py
@@ -22,6 +22,7 @@ from .const import (
     CONF_MODEL,
     CONF_STATUS,
     CONF_STATUS_NUDGE,
+    CONF_UPDATE_WATCHDOG,
     DOMAIN,
 )
 from .coordinator import PhilipsAirPurifierCoordinator
@@ -94,6 +95,7 @@ async def async_setup_entry(
         host,
         device_information,
         status_nudge_enabled=entry.options.get(CONF_STATUS_NUDGE),
+        update_watchdog_enabled=entry.options.get(CONF_UPDATE_WATCHDOG, True),
     )
 
     # Perform initial data refresh, then start CoAP observation

--- a/custom_components/philips_airpurifier/__init__.py
+++ b/custom_components/philips_airpurifier/__init__.py
@@ -21,6 +21,7 @@ from .const import (
     CONF_MAC,
     CONF_MODEL,
     CONF_STATUS,
+    CONF_STATUS_NUDGE,
     DOMAIN,
 )
 from .coordinator import PhilipsAirPurifierCoordinator
@@ -87,7 +88,13 @@ async def async_setup_entry(
         device_id=device_id,
     )
 
-    coordinator = PhilipsAirPurifierCoordinator(hass, client, host, device_information)
+    coordinator = PhilipsAirPurifierCoordinator(
+        hass,
+        client,
+        host,
+        device_information,
+        status_nudge_enabled=entry.options.get(CONF_STATUS_NUDGE),
+    )
 
     # Perform initial data refresh, then start CoAP observation
     await coordinator.async_first_refresh_and_observe()

--- a/custom_components/philips_airpurifier/__init__.py
+++ b/custom_components/philips_airpurifier/__init__.py
@@ -96,6 +96,9 @@ async def async_setup_entry(
         update_watchdog_enabled=entry.options.get(CONF_UPDATE_WATCHDOG, True),
     )
 
+    if not entry.options.get(CONF_UPDATE_WATCHDOG, True) and CONF_STATUS in entry.data:
+        coordinator.async_set_updated_data(entry.data[CONF_STATUS])
+
     # Perform initial data refresh, then start CoAP observation
     await coordinator.async_first_refresh_and_observe()
 

--- a/custom_components/philips_airpurifier/__init__.py
+++ b/custom_components/philips_airpurifier/__init__.py
@@ -21,7 +21,6 @@ from .const import (
     CONF_MAC,
     CONF_MODEL,
     CONF_STATUS,
-    CONF_STATUS_NUDGE,
     CONF_UPDATE_WATCHDOG,
     DOMAIN,
 )
@@ -94,7 +93,6 @@ async def async_setup_entry(
         client,
         host,
         device_information,
-        status_nudge_enabled=entry.options.get(CONF_STATUS_NUDGE),
         update_watchdog_enabled=entry.options.get(CONF_UPDATE_WATCHDOG, True),
     )
 

--- a/custom_components/philips_airpurifier/config_flow.py
+++ b/custom_components/philips_airpurifier/config_flow.py
@@ -25,7 +25,7 @@ from .const import (
     CONF_MAC,
     CONF_MODEL,
     CONF_STATUS,
-    CONF_STATUS_NUDGE,
+    CONF_UPDATE_WATCHDOG,
     DOMAIN,
     PhilipsApi,
 )
@@ -432,13 +432,6 @@ class PhilipsAirPurifierOptionsFlow(OptionsFlowWithReload):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Manage Philips AirPurifier options."""
-        model = self.config_entry.data.get(CONF_MODEL)
-        model_config = DEVICE_MODELS.get(model)
-
-        if model_config is None or not model_config.status_nudge:
-            return self.async_abort(reason="status_nudge_not_supported")
-
-        default_status_nudge = True
 
         if user_input is not None:
             return self.async_create_entry(data=user_input)
@@ -448,10 +441,10 @@ class PhilipsAirPurifierOptionsFlow(OptionsFlowWithReload):
             data_schema=vol.Schema(
                 {
                     vol.Required(
-                        CONF_STATUS_NUDGE,
+                        CONF_UPDATE_WATCHDOG,
                         default=self.config_entry.options.get(
-                            CONF_STATUS_NUDGE,
-                            default_status_nudge,
+                            CONF_UPDATE_WATCHDOG,
+                            True,
                         ),
                     ): bool,
                 }

--- a/custom_components/philips_airpurifier/config_flow.py
+++ b/custom_components/philips_airpurifier/config_flow.py
@@ -10,6 +10,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries, exceptions
 from homeassistant.config_entries import ConfigFlowResult, OptionsFlowWithReload
+from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
@@ -32,6 +33,7 @@ from .device_models import DEVICE_MODELS
 from .helpers import extract_model, extract_name
 
 _LOGGER = logging.getLogger(__name__)
+
 
 def host_valid(host: str) -> bool:
     """Return True if hostname or IP address is valid."""
@@ -422,6 +424,7 @@ class InvalidHost(exceptions.HomeAssistantError):
 class CannotConnect(exceptions.HomeAssistantError):
     """Error to indicate that the device could not be reached."""
 
+
 class PhilipsAirPurifierOptionsFlow(OptionsFlowWithReload):
     """Handle Philips AirPurifier options."""
 
@@ -432,9 +435,10 @@ class PhilipsAirPurifierOptionsFlow(OptionsFlowWithReload):
         model = self.config_entry.data.get(CONF_MODEL)
         model_config = DEVICE_MODELS.get(model)
 
-        default_status_nudge = bool(
-            model_config is not None and model_config.status_nudge
-        )
+        if model_config is None or not model_config.status_nudge:
+            return self.async_abort(reason="status_nudge_not_supported")
+
+        default_status_nudge = True
 
         if user_input is not None:
             return self.async_create_entry(data=user_input)

--- a/custom_components/philips_airpurifier/config_flow.py
+++ b/custom_components/philips_airpurifier/config_flow.py
@@ -9,8 +9,7 @@ from philips_airctrl import CoAPClient
 import voluptuous as vol
 
 from homeassistant import config_entries, exceptions
-from homeassistant.config_entries import ConfigFlowResult
-from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.config_entries import ConfigFlowResult, OptionsFlowWithReload
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
@@ -20,12 +19,19 @@ from .client import (
     async_fetch_status,
     async_fetch_status_with_nudge,
 )
-from .const import CONF_DEVICE_ID, CONF_MAC, CONF_MODEL, CONF_STATUS, DOMAIN, PhilipsApi
+from .const import (
+    CONF_DEVICE_ID,
+    CONF_MAC,
+    CONF_MODEL,
+    CONF_STATUS,
+    CONF_STATUS_NUDGE,
+    DOMAIN,
+    PhilipsApi,
+)
 from .device_models import DEVICE_MODELS
 from .helpers import extract_model, extract_name
 
 _LOGGER = logging.getLogger(__name__)
-
 
 def host_valid(host: str) -> bool:
     """Return True if hostname or IP address is valid."""
@@ -42,6 +48,13 @@ class PhilipsAirPurifierConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle config flow for Philips AirPurifier."""
 
     VERSION = 1
+
+    @staticmethod
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
+        """Create the options flow."""
+        return PhilipsAirPurifierOptionsFlow()
 
     def __init__(self) -> None:
         """Initialize."""
@@ -408,3 +421,35 @@ class InvalidHost(exceptions.HomeAssistantError):
 
 class CannotConnect(exceptions.HomeAssistantError):
     """Error to indicate that the device could not be reached."""
+
+class PhilipsAirPurifierOptionsFlow(OptionsFlowWithReload):
+    """Handle Philips AirPurifier options."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage Philips AirPurifier options."""
+        model = self.config_entry.data.get(CONF_MODEL)
+        model_config = DEVICE_MODELS.get(model)
+
+        default_status_nudge = bool(
+            model_config is not None and model_config.status_nudge
+        )
+
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_STATUS_NUDGE,
+                        default=self.config_entry.options.get(
+                            CONF_STATUS_NUDGE,
+                            default_status_nudge,
+                        ),
+                    ): bool,
+                }
+            ),
+        )

--- a/custom_components/philips_airpurifier/const.py
+++ b/custom_components/philips_airpurifier/const.py
@@ -51,6 +51,7 @@ CONF_STATUS = "status"
 # with a network-MAC connection, which lets the `registered_devices` DHCP matcher
 # re-discover the device and update its IP after a DHCP lease change. See issue #8.
 CONF_MAC = "mac"
+CONF_STATUS_NUDGE = "status_nudge"
 
 # Config-entry option flag set when the user acknowledges the filter
 # replacement repair, so it is not recreated on every coordinator update.

--- a/custom_components/philips_airpurifier/const.py
+++ b/custom_components/philips_airpurifier/const.py
@@ -51,7 +51,6 @@ CONF_STATUS = "status"
 # with a network-MAC connection, which lets the `registered_devices` DHCP matcher
 # re-discover the device and update its IP after a DHCP lease change. See issue #8.
 CONF_MAC = "mac"
-CONF_STATUS_NUDGE = "status_nudge"
 CONF_UPDATE_WATCHDOG = "update_watchdog"
 
 # Config-entry option flag set when the user acknowledges the filter

--- a/custom_components/philips_airpurifier/const.py
+++ b/custom_components/philips_airpurifier/const.py
@@ -52,6 +52,7 @@ CONF_STATUS = "status"
 # re-discover the device and update its IP after a DHCP lease change. See issue #8.
 CONF_MAC = "mac"
 CONF_STATUS_NUDGE = "status_nudge"
+CONF_UPDATE_WATCHDOG = "update_watchdog"
 
 # Config-entry option flag set when the user acknowledges the filter
 # replacement repair, so it is not recreated on every coordinator update.

--- a/custom_components/philips_airpurifier/coordinator.py
+++ b/custom_components/philips_airpurifier/coordinator.py
@@ -38,6 +38,7 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         host: str,
         device_info: DeviceInformation,
         status_nudge_enabled: bool | None = None,
+        update_watchdog_enabled: bool = True,
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(
@@ -58,6 +59,7 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             else model_has_status_nudge and status_nudge_enabled
         )
 
+        self._update_watchdog_enabled = update_watchdog_enabled
         self._observe_task: asyncio.Task[None] | None = None
         self._reconnect_task: asyncio.Task[None] | None = None
         self._reconnect_retry_task: asyncio.Task[None] | None = None
@@ -211,7 +213,7 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             f"philips_airpurifier_observe_{self.host}",
         )
 
-        if self._status_nudge_enabled:
+        if self._status_nudge_enabled or not self._update_watchdog_enabled:
             # Nudge-only devices push status only on a real state change, so an
             # idle device legitimately sends nothing. A periodic watchdog would
             # force needless reconnects (each re-toggling the nudge value) while

--- a/custom_components/philips_airpurifier/coordinator.py
+++ b/custom_components/philips_airpurifier/coordinator.py
@@ -347,6 +347,12 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._start_observing()
             return
 
+        if not self._update_watchdog_enabled and self.data is not None:
+            self._last_update = asyncio.get_event_loop().time()
+            self._mark_available()
+            self._start_observing()
+            return
+
         try:
             # One-shot initial read; continuous updates come from the observe
             # stream started below, so don't register a second observation here.

--- a/custom_components/philips_airpurifier/coordinator.py
+++ b/custom_components/philips_airpurifier/coordinator.py
@@ -37,7 +37,6 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         client: CoAPClient,
         host: str,
         device_info: DeviceInformation,
-        status_nudge_enabled: bool | None = None,
         update_watchdog_enabled: bool = True,
     ) -> None:
         """Initialize the coordinator."""
@@ -50,13 +49,8 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.host = host
         self.device_info = device_info
 
-        model_has_status_nudge = bool(
+        self._status_nudge_enabled = bool(
             getattr(self.model_config, "status_nudge", None)
-        )
-        self._status_nudge_enabled = (
-            model_has_status_nudge
-            if status_nudge_enabled is None
-            else model_has_status_nudge and status_nudge_enabled
         )
 
         self._update_watchdog_enabled = update_watchdog_enabled

--- a/custom_components/philips_airpurifier/coordinator.py
+++ b/custom_components/philips_airpurifier/coordinator.py
@@ -37,6 +37,7 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         client: CoAPClient,
         host: str,
         device_info: DeviceInformation,
+        status_nudge_enabled: bool | None = None,
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(
@@ -47,6 +48,15 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.client = client
         self.host = host
         self.device_info = device_info
+
+        model_has_status_nudge = bool(
+            getattr(self.model_config, "status_nudge", None)
+        )
+        self._status_nudge_enabled = (
+            model_has_status_nudge
+            if status_nudge_enabled is None
+            else model_has_status_nudge and status_nudge_enabled
+        )
 
         self._observe_task: asyncio.Task[None] | None = None
         self._reconnect_task: asyncio.Task[None] | None = None
@@ -166,7 +176,7 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from the device (used for initial refresh and fallback)."""
-        if self.model_config.status_nudge:
+        if self._status_nudge_enabled:
             # This firmware never answers a status read; ongoing state comes
             # from the observe stream. Return the last pushed status if we have
             # it, otherwise force one push via a nudge.
@@ -201,7 +211,7 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             f"philips_airpurifier_observe_{self.host}",
         )
 
-        if self.model_config.status_nudge:
+        if self._status_nudge_enabled:
             # Nudge-only devices push status only on a real state change, so an
             # idle device legitimately sends nothing. A periodic watchdog would
             # force needless reconnects (each re-toggling the nudge value) while
@@ -296,7 +306,7 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             with contextlib.suppress(Exception):
                 await self.client.shutdown()
 
-            if self.model_config.status_nudge:
+            if self._status_nudge_enabled:
                 # Re-fetch via nudge before re-establishing the observe stream.
                 # _async_refresh_via_nudge owns the coordinator client here: a
                 # client created now would be evicted by the nudge helper's
@@ -328,7 +338,7 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def async_first_refresh_and_observe(self) -> None:
         """Perform first refresh and start observing."""
-        if self.model_config.status_nudge:
+        if self._status_nudge_enabled:
             try:
                 # This firmware never answers a status read; force the first
                 # push with a nudge, then observe for subsequent changes.

--- a/custom_components/philips_airpurifier/icons.json
+++ b/custom_components/philips_airpurifier/icons.json
@@ -13,7 +13,7 @@
               "auto_general": "mdi:autorenew",
               "auto_plus": "mdi:autorenew",
               "bacteria": "mdi:biohazard",
-              "allergen": "mdi:flower-pollen",
+              "allergen": "mdi:flower-pollen-outline",
               "gentle": "mdi:fan",
               "night": "mdi:weather-night",
               "sleep": "mdi:weather-night",
@@ -55,7 +55,7 @@
               "purification": "mdi:air-filter",
               "purification_humidification": "mdi:water-percent",
               "auto": "mdi:autorenew",
-              "allergen": "mdi:flower-pollen",
+              "allergen": mdi:flower-pollen-outline",
               "sleep": "mdi:weather-night",
               "night": "mdi:weather-night",
               "turbo": "mdi:fan",
@@ -122,7 +122,7 @@
     },
     "sensor": {
       "indoor_allergen_index": {
-        "default": "mdi:eye"
+        "default": "mdi:flower-pollen-outline"
       },
       "pm25": {
         "default": "mdi:blur"
@@ -218,7 +218,7 @@
       "preferred_index": {
         "default": "mdi:gauge",
         "state": {
-          "indoor_allergen_index": "mdi:eye",
+          "indoor_allergen_index": "mdi:flower-pollen-outline",
           "pm25": "mdi:blur",
           "gas_level": "mdi:molecule"
         }
@@ -230,7 +230,7 @@
           "auto_general": "mdi:autorenew",
           "auto_plus": "mdi:autorenew",
           "bacteria": "mdi:biohazard",
-          "allergen": "mdi:flower-pollen",
+          "allergen": "mdi:flower-pollen-outline",
           "gentle": "mdi:fan",
           "night": "mdi:weather-night",
           "sleep": "mdi:weather-night",

--- a/custom_components/philips_airpurifier/strings.json
+++ b/custom_components/philips_airpurifier/strings.json
@@ -32,14 +32,11 @@
     }
   },
   "options": {
-    "abort": {
-      "status_nudge_not_supported": "Status nudge is not supported for this device"
-    },
     "step": {
       "init": {
-        "title": "Status nudge",
+        "title": "Update watchdog",
         "data": {
-          "status_nudge": "Enable status nudge"
+          "update_watchdog": "Enable update watchdog"
         }
       }
     }

--- a/custom_components/philips_airpurifier/strings.json
+++ b/custom_components/philips_airpurifier/strings.json
@@ -31,6 +31,19 @@
       "cannot_connect": "Cannot connect to device"
     }
   },
+  "options": {
+    "abort": {
+      "status_nudge_not_supported": "Status nudge is not supported for this device"
+    },
+    "step": {
+      "init": {
+        "title": "Status nudge",
+        "data": {
+          "status_nudge": "Enable status nudge"
+        }
+      }
+    }
+  },
   "entity": {
     "fan": {
       "pap": {

--- a/custom_components/philips_airpurifier/translations/en.json
+++ b/custom_components/philips_airpurifier/translations/en.json
@@ -32,14 +32,11 @@
     }
   },
   "options": {
-    "abort": {
-      "status_nudge_not_supported": "Status nudge is not supported for this device"
-    },
     "step": {
       "init": {
-        "title": "Status nudge",
+        "title": "Update watchdog",
         "data": {
-          "status_nudge": "Enable status nudge"
+          "update_watchdog": "Enable update watchdog"
         }
       }
     }

--- a/custom_components/philips_airpurifier/translations/en.json
+++ b/custom_components/philips_airpurifier/translations/en.json
@@ -31,6 +31,19 @@
       "cannot_connect": "Cannot connect to device"
     }
   },
+  "options": {
+    "abort": {
+      "status_nudge_not_supported": "Status nudge is not supported for this device"
+    },
+    "step": {
+      "init": {
+        "title": "Status nudge",
+        "data": {
+          "status_nudge": "Enable status nudge"
+        }
+      }
+    }
+  },
   "entity": {
     "fan": {
       "pap": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -11,6 +11,7 @@ from custom_components.philips_airpurifier.const import (
     CONF_DEVICE_ID,
     CONF_MAC,
     CONF_MODEL,
+    CONF_STATUS_NUDGE,
     CONF_STATUS,
     DOMAIN,
     PhilipsApi,
@@ -1060,3 +1061,75 @@ async def test_user_flow_model_family_supported_branch(hass: HomeAssistant) -> N
         )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_options_flow_status_nudge_supported(hass: HomeAssistant) -> None:
+    """Test status nudge option is available for supported models."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_MODEL: "CX7550",
+            CONF_NAME: TEST_NAME,
+            CONF_DEVICE_ID: TEST_DEVICE_ID,
+            CONF_STATUS: MOCK_STATUS_GEN1,
+        },
+        unique_id=TEST_DEVICE_ID,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+
+async def test_options_flow_status_nudge_can_be_disabled(
+    hass: HomeAssistant,
+) -> None:
+    """Test status nudge can be disabled per device."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_MODEL: "CX7550",
+            CONF_NAME: TEST_NAME,
+            CONF_DEVICE_ID: TEST_DEVICE_ID,
+            CONF_STATUS: MOCK_STATUS_GEN1,
+        },
+        unique_id=TEST_DEVICE_ID,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={CONF_STATUS_NUDGE: False},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_STATUS_NUDGE] is False
+
+
+async def test_options_flow_status_nudge_not_supported(
+    hass: HomeAssistant,
+) -> None:
+    """Test status nudge option aborts for unsupported models."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_MODEL: TEST_MODEL,
+            CONF_NAME: TEST_NAME,
+            CONF_DEVICE_ID: TEST_DEVICE_ID,
+            CONF_STATUS: MOCK_STATUS_GEN1,
+        },
+        unique_id=TEST_DEVICE_ID,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "status_nudge_not_supported"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -11,7 +11,7 @@ from custom_components.philips_airpurifier.const import (
     CONF_DEVICE_ID,
     CONF_MAC,
     CONF_MODEL,
-    CONF_STATUS_NUDGE,
+    CONF_UPDATE_WATCHDOG,
     CONF_STATUS,
     DOMAIN,
     PhilipsApi,
@@ -1063,59 +1063,10 @@ async def test_user_flow_model_family_supported_branch(hass: HomeAssistant) -> N
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-async def test_options_flow_status_nudge_supported(hass: HomeAssistant) -> None:
-    """Test status nudge option is available for supported models."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_HOST: TEST_HOST,
-            CONF_MODEL: "CX7550",
-            CONF_NAME: TEST_NAME,
-            CONF_DEVICE_ID: TEST_DEVICE_ID,
-            CONF_STATUS: MOCK_STATUS_GEN1,
-        },
-        unique_id=TEST_DEVICE_ID,
-    )
-    entry.add_to_hass(hass)
-
-    result = await hass.config_entries.options.async_init(entry.entry_id)
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "init"
-
-
-async def test_options_flow_status_nudge_can_be_disabled(
+async def test_options_flow_update_watchdog_available(
     hass: HomeAssistant,
 ) -> None:
-    """Test status nudge can be disabled per device."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_HOST: TEST_HOST,
-            CONF_MODEL: "CX7550",
-            CONF_NAME: TEST_NAME,
-            CONF_DEVICE_ID: TEST_DEVICE_ID,
-            CONF_STATUS: MOCK_STATUS_GEN1,
-        },
-        unique_id=TEST_DEVICE_ID,
-    )
-    entry.add_to_hass(hass)
-
-    result = await hass.config_entries.options.async_init(entry.entry_id)
-
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={CONF_STATUS_NUDGE: False},
-    )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert entry.options[CONF_STATUS_NUDGE] is False
-
-
-async def test_options_flow_status_nudge_not_supported(
-    hass: HomeAssistant,
-) -> None:
-    """Test status nudge option aborts for unsupported models."""
+    """Test update watchdog option is available for devices."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -1131,5 +1082,33 @@ async def test_options_flow_status_nudge_not_supported(
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "status_nudge_not_supported"
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+
+async def test_options_flow_update_watchdog_can_be_disabled(
+    hass: HomeAssistant,
+) -> None:
+    """Test update watchdog can be disabled per device."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_MODEL: TEST_MODEL,
+            CONF_NAME: TEST_NAME,
+            CONF_DEVICE_ID: TEST_DEVICE_ID,
+            CONF_STATUS: MOCK_STATUS_GEN1,
+        },
+        unique_id=TEST_DEVICE_ID,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={CONF_UPDATE_WATCHDOG: False},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_UPDATE_WATCHDOG] is False

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -205,6 +205,7 @@ def _make_coordinator(
     *,
     model: str = TEST_MODEL,
     client: AsyncMock | None = None,
+    update_watchdog_enabled: bool = True,
 ) -> PhilipsAirPurifierCoordinator:
     """Create a coordinator instance for unit-path testing."""
     device_info = DeviceInformation(
@@ -213,7 +214,13 @@ def _make_coordinator(
         device_id=TEST_DEVICE_ID,
         host=TEST_HOST,
     )
-    return PhilipsAirPurifierCoordinator(hass, client or AsyncMock(), TEST_HOST, device_info)
+    return PhilipsAirPurifierCoordinator(
+        hass,
+        client or AsyncMock(),
+        TEST_HOST,
+        device_info,
+        update_watchdog_enabled=update_watchdog_enabled,
+    )
 
 
 async def test_coordinator_model_config_family_fallback(hass: HomeAssistant) -> None:
@@ -262,6 +269,27 @@ async def test_start_observing_without_existing_tasks(hass: HomeAssistant) -> No
         coordinator._start_observing()
 
     assert create_task.call_count == 2
+
+
+async def test_start_observing_watchdog_disabled(
+    hass: HomeAssistant,
+) -> None:
+    """Test observing starts without watchdog when the option is disabled."""
+    coordinator = _make_coordinator(
+        hass,
+        update_watchdog_enabled=False,
+    )
+
+    with patch.object(coordinator, "_async_observe_status", AsyncMock()):
+        coordinator._start_observing()
+
+    assert coordinator._observe_task is not None
+    assert coordinator._watchdog_task is None
+
+    observe_task = coordinator._observe_task
+    observe_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await observe_task
 
 
 async def test_async_observe_status_cancelled_raises(hass: HomeAssistant) -> None:


### PR DESCRIPTION
(ha-philips) XXX@HPMartin:/mnt/c/Users/XXX/.copilot/repos/copilot-worktrees/ha-philips-airpurifier/martin-g-it-animated-winner$ pytest
========================================================================================================================== test session starts ==========================================================================================================================
platform linux -- Python 3.14.4, pytest-9.0.3, pluggy-1.6.0
rootdir: /mnt/c/Users/XXX/.copilot/repos/copilot-worktrees/ha-philips-airpurifier/martin-g-it-animated-winner
configfile: pyproject.toml
testpaths: tests
plugins: cov-7.1.0, asyncio-1.4.0, pytest_freezer-0.4.9, requests-mock-1.12.1, respx-0.23.1, homeassistant-custom-component-0.13.356, anyio-4.14.2, aiohttp-1.1.1, syrupy-5.5.3, socket-0.8.0, unordered-0.8.0, picked-0.5.1, github-actions-annotate-failures-0.4.2, xdist-3.8.0, timeout-2.4.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 374 items

tests/test_binary_sensor.py .......                                                                                                                                                                                                                               [  1%]
tests/test_client.py .......                                                                                                                                                                                                                                      [  3%]
tests/test_climate.py ............................                                                                                                                                                                                                                [ 11%]
tests/test_config_flow.py .....................................                                                                                                                                                                                                   [ 21%]
tests/test_const.py ......                                                                                                                                                                                                                                        [ 22%]
tests/test_coordinator.py ...............................................                                                                                                                                                                                         [ 35%]
tests/test_diagnostics.py .........                                                                                                                                                                                                                               [ 37%]
tests/test_event.py ........                                                                                                                                                                                                                                      [ 39%]
tests/test_fan.py ............................                                                                                                                                                                                                                    [ 47%]
tests/test_helpers.py ..............................                                                                                                                                                                                                              [ 55%]
tests/test_humidifier.py ...............                                                                                                                                                                                                                          [ 59%]
tests/test_init.py .....                                                                                                                                                                                                                                          [ 60%]
tests/test_light.py ...............                                                                                                                                                                                                                               [ 64%]
tests/test_model.py ..............                                                                                                                                                                                                                                [ 68%]
tests/test_number.py ...........                                                                                                                                                                                                                                  [ 71%]
tests/test_repairs.py ....................................                                                                                                                                                                                                        [ 81%]
tests/test_select.py .......................                                                                                                                                                                                                                      [ 87%]
tests/test_sensor.py .........................                                                                                                                                                                                                                    [ 93%]
tests/test_services.py ...............                                                                                                                                                                                                                            [ 97%]
tests/test_switch.py ........                                                                                                                                                                                                                                     [100%]

=========================================================================================================================== warnings summary ============================================================================================================================
../../../../../../../../../home/XXX/venvs/ha-philips/lib/python3.14/site-packages/_pytest/cacheprovider.py:475
  /home/XXX/venvs/ha-philips/lib/python3.14/site-packages/_pytest/cacheprovider.py:475: PytestCacheWarning: could not create cache path /mnt/c/Users/XXX/.copilot/repos/copilot-worktrees/ha-philips-airpurifier/martin-g-it-animated-winner/.pytest_cache/v/cache/nodeids: [Errno 1] Operation not permitted: '/mnt/c/Users/XXX/.copilot/repos/copilot-worktrees/ha-philips-airpurifier/martin-g-it-animated-winner/pytest-cache-files-w9by0aid'
    config.cache.set("cache/nodeids", sorted(self.cached_nodeids))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================================== 374 passed, 1 warning in 205.40s (0:03:25) ===============================================================================================================

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an options setting to enable or disable update watchdog monitoring.
  - Watchdog monitoring is enabled by default and can be changed for existing devices.
  - Improved status updates for compatible air purifier models through configurable status nudging.

- **Bug Fixes**
  - Prevented unnecessary watchdog scheduling on devices that support status nudging.

- **Tests**
  - Added coverage for configuring the watchdog and verifying monitoring behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->