### PR TITLE
fix(coordinator): bound the CoAP calls so a stalled reconnect cannot wedge

### DIFF
--- a/custom_components/philips_airpurifier/coordinator.py
+++ b/custom_components/philips_airpurifier/coordinator.py
@@ -27,6 +27,20 @@ DEFAULT_TIMEOUT = 60
 RECONNECT_INITIAL_DELAY = 5
 RECONNECT_MAX_DELAY = 60
 
+# Every CoAP call the coordinator makes is bounded. `get_status` awaits an
+# aiocoap response built with `transport_tuning=Unreliable` and has no internal
+# timeout, so a device that accepts a request and never answers leaves the
+# await pending indefinitely. The helpers in client.py already bound their
+# calls; these are the coordinator's own.
+COAP_CALL_TIMEOUT = 30
+SHUTDOWN_TIMEOUT = 10
+
+# A reconnect older than this is treated as wedged rather than in progress.
+# Without it, `_async_reconnect`'s duplicate guard turns one stuck await into a
+# permanent stall: the task is never `done()`, so every later attempt returns
+# immediately and neither the success nor the failure branch is ever reached.
+RECONNECT_TASK_MAX = 120
+
 
 class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Coordinator to manage data from Philips AirPurifier via CoAP push."""
@@ -55,6 +69,9 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._watchdog_task: asyncio.Task[None] | None = None
         self._last_update: float = 0.0
         self._reconnect_delay: int = RECONNECT_INITIAL_DELAY
+        # Event-loop time at which the current reconnect task started, so a
+        # wedged reconnect can be told from a slow one. None when idle.
+        self._reconnect_started: float | None = None
         self._device_available = True
         self._shutting_down: bool = False
 
@@ -111,7 +128,7 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def async_set_control_values(self, values: dict[str, Any]) -> None:
         """Set multiple control values on the device."""
-        await self.client.set_control_values(data=values)
+        await asyncio.wait_for(self.client.set_control_values(data=values), timeout=COAP_CALL_TIMEOUT)
 
     def _build_status_nudge(self) -> list[tuple[str, Any]]:
         """Build the nudge write sequence for a push-on-change device.
@@ -156,7 +173,7 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # first and recreate it afterwards — otherwise the observe stream started
         # after this would attach to the connection the nudge just evicted.
         with contextlib.suppress(Exception):
-            await self.client.shutdown()
+            await asyncio.wait_for(self.client.shutdown(), timeout=SHUTDOWN_TIMEOUT)
         status = await self._async_nudge_fetch()
         self.client = await async_create_client(self.host, create_client=CoAPClient.create)
         self._timeout = DEFAULT_TIMEOUT
@@ -182,7 +199,7 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             # One-shot read: ongoing updates come from the observe stream, so
             # avoid registering a redundant observation (philips-airctrl >= 1.1.0).
-            status, timeout = await self.client.get_status(observe=False)
+            status, timeout = await asyncio.wait_for(self.client.get_status(observe=False), timeout=COAP_CALL_TIMEOUT)
             self._timeout = timeout
             self._mark_available()
             return status
@@ -256,7 +273,19 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _async_reconnect(self) -> None:
         """Reconnect to the device."""
         if self._reconnect_task is not None and not self._reconnect_task.done():
-            return
+            age = (
+                asyncio.get_event_loop().time() - self._reconnect_started
+                if self._reconnect_started is not None
+                else None
+            )
+            if age is None or age < RECONNECT_TASK_MAX:
+                return
+            _LOGGER.warning(
+                "Previous reconnect to %s has been running for %d seconds, cancelling it and starting a new one",
+                self.host,
+                int(age),
+            )
+            self._reconnect_task.cancel()
 
         current_task = asyncio.current_task()
         if (
@@ -267,6 +296,7 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._reconnect_retry_task.cancel()
             self._reconnect_retry_task = None
 
+        self._reconnect_started = asyncio.get_event_loop().time()
         self._reconnect_task = self.hass.async_create_background_task(
             self._do_reconnect(),
             f"philips_airpurifier_reconnect_{self.host}",
@@ -294,7 +324,7 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Perform the actual reconnect."""
         try:
             with contextlib.suppress(Exception):
-                await self.client.shutdown()
+                await asyncio.wait_for(self.client.shutdown(), timeout=SHUTDOWN_TIMEOUT)
 
             if self.model_config.status_nudge:
                 # Re-fetch via nudge before re-establishing the observe stream.
@@ -305,7 +335,9 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             else:
                 self.client = await async_create_client(self.host, create_client=CoAPClient.create)
                 # One-shot read before re-establishing the observe stream.
-                status, timeout = await self.client.get_status(observe=False)
+                status, timeout = await asyncio.wait_for(
+                    self.client.get_status(observe=False), timeout=COAP_CALL_TIMEOUT
+                )
                 self._timeout = timeout
                 self._last_update = asyncio.get_event_loop().time()
                 self._mark_available()
@@ -344,7 +376,7 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             # One-shot initial read; continuous updates come from the observe
             # stream started below, so don't register a second observation here.
-            status, timeout = await self.client.get_status(observe=False)
+            status, timeout = await asyncio.wait_for(self.client.get_status(observe=False), timeout=COAP_CALL_TIMEOUT)
             self._timeout = timeout
             self._mark_available()
             self.async_set_updated_data(status)
@@ -382,4 +414,4 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 await task
 
         with contextlib.suppress(Exception):
-            await self.client.shutdown()
+            await asyncio.wait_for(self.client.shutdown(), timeout=SHUTDOWN_TIMEOUT)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -10,6 +10,7 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.philips_airpurifier.coordinator import (
+    RECONNECT_INITIAL_DELAY,
     PhilipsAirPurifierCoordinator,
 )
 from custom_components.philips_airpurifier.model import DeviceInformation
@@ -749,3 +750,130 @@ async def test_do_reconnect_nudge(hass: HomeAssistant) -> None:
         await coordinator._do_reconnect()
 
     assert coordinator.data == _CX_STATUS
+
+
+async def test_do_reconnect_times_out_instead_of_hanging(hass: HomeAssistant) -> None:
+    """Test a device that accepts a status read and never answers still fails the reconnect.
+
+    `get_status` has no internal timeout, so without a bound here the await never
+    returns: `_do_reconnect` reaches neither its success nor its failure branch,
+    and the task stays not-done for ever. `_async_reconnect`'s duplicate guard
+    then makes every later attempt a no-op, so the watchdog keeps firing into a
+    function that returns immediately and nothing is ever logged.
+    """
+    coordinator = _make_coordinator(hass, client=AsyncMock())
+
+    async def _never(*_args, **_kwargs):
+        await asyncio.sleep(3600)
+
+    silent_client = MagicMock()
+    silent_client.get_status = _never
+    silent_client.shutdown = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.philips_airpurifier.coordinator.async_create_client",
+            new=AsyncMock(return_value=silent_client),
+        ),
+        patch("custom_components.philips_airpurifier.coordinator.COAP_CALL_TIMEOUT", 0.05),
+        patch.object(coordinator, "_schedule_reconnect_retry") as retry,
+        patch.object(coordinator, "_mark_unavailable") as mark_unavailable,
+        patch.object(coordinator, "_start_observing") as start_observing,
+    ):
+        await asyncio.wait_for(coordinator._do_reconnect(), timeout=5)
+
+    retry.assert_called_once_with(RECONNECT_INITIAL_DELAY)
+    mark_unavailable.assert_called_once_with("reconnect failed")
+    start_observing.assert_not_called()
+    assert coordinator._reconnect_delay > RECONNECT_INITIAL_DELAY
+
+
+async def test_do_reconnect_survives_a_hanging_shutdown(hass: HomeAssistant) -> None:
+    """Test a client whose shutdown() never returns does not block the reconnect.
+
+    That call runs before anything else in `_do_reconnect`, so an unbounded one
+    stalls the reconnect before it has even tried to reach the device.
+    """
+
+    async def _never_shutdown():
+        await asyncio.sleep(3600)
+
+    stuck_client = MagicMock()
+    stuck_client.shutdown = _never_shutdown
+    coordinator = _make_coordinator(hass, client=stuck_client)
+
+    fresh_client = AsyncMock()
+    fresh_client.get_status = AsyncMock(return_value=(MOCK_STATUS_GEN1, 60))
+
+    with (
+        patch(
+            "custom_components.philips_airpurifier.coordinator.async_create_client",
+            new=AsyncMock(return_value=fresh_client),
+        ),
+        patch("custom_components.philips_airpurifier.coordinator.SHUTDOWN_TIMEOUT", 0.05),
+        patch.object(coordinator, "_schedule_reconnect_retry") as retry,
+        patch.object(coordinator, "_start_observing") as start_observing,
+    ):
+        await asyncio.wait_for(coordinator._do_reconnect(), timeout=5)
+
+    start_observing.assert_called_once()
+    retry.assert_not_called()
+
+
+async def test_async_reconnect_cancels_a_wedged_reconnect(hass: HomeAssistant) -> None:
+    """Test a reconnect older than the ceiling is cancelled rather than deferred to."""
+    coordinator = _make_coordinator(hass)
+
+    async def _wedged():
+        await asyncio.sleep(3600)
+
+    wedged_task = asyncio.create_task(_wedged())
+    coordinator._reconnect_task = wedged_task
+    coordinator._reconnect_started = asyncio.get_event_loop().time() - 10_000
+
+    def _close_and_mock(coro, *_args, **_kwargs):
+        # Close the coroutine we are not running, or pytest reports it as never
+        # awaited. Same approach as test_async_observe_status_error_triggers_reconnect.
+        coro.close()
+        return MagicMock()
+
+    try:
+        with (
+            patch("custom_components.philips_airpurifier.coordinator.RECONNECT_TASK_MAX", 1),
+            patch.object(hass, "async_create_background_task", side_effect=_close_and_mock) as create_task,
+        ):
+            await coordinator._async_reconnect()
+
+        create_task.assert_called_once()
+        assert wedged_task.cancelled() or wedged_task.cancelling()
+    finally:
+        wedged_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await wedged_task
+
+
+async def test_async_reconnect_leaves_a_young_reconnect_alone(hass: HomeAssistant) -> None:
+    """Test the duplicate guard still holds for a reconnect that has just started.
+
+    The ceiling must not turn into "always replace": a reconnect in progress is
+    the case the guard exists for.
+    """
+    coordinator = _make_coordinator(hass)
+
+    async def _running():
+        await asyncio.sleep(3600)
+
+    young_task = asyncio.create_task(_running())
+    coordinator._reconnect_task = young_task
+    coordinator._reconnect_started = asyncio.get_event_loop().time()
+
+    try:
+        with patch.object(hass, "async_create_background_task") as create_task:
+            await coordinator._async_reconnect()
+
+        create_task.assert_not_called()
+        assert not young_task.cancelled()
+    finally:
+        young_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await young_task


### PR DESCRIPTION
### What happens

Two AMF devices went unavailable and never recovered. The watchdog logged

```
No updates from <device-ip> for N seconds, reconnecting
```

every three minutes for over four hours — and **`N` grew by exactly the
watchdog interval each time**, so `_last_update` never moved once.

The devices were fine throughout: a one-shot CoAP read from the same machine,
using this integration's own `async_fetch_status` with `observe=False`,
returned a full 58-key status in **0.1–0.4 s** for both, `ConnectType = Online`.

### The evidence is what the log does *not* contain

`_do_reconnect` logs on **both** outcomes:

```python
_LOGGER.info("Reconnected to %s", self.host)                            # success
_LOGGER.warning("Reconnect to %s failed, retrying in %s seconds", ...)  # failure
```

Across four hours and dozens of watchdog firings, **neither line appeared once**.
The reconnect task neither succeeded nor failed — it never completed.

### Why

1. `_do_reconnect` awaited `self.client.get_status(observe=False)` **unbounded**.
   The helpers in `client.py` are bounded — `async_create_client` at 25 s,
   `async_fetch_status` at 30 s — but the coordinator's own calls were not.
2. `get_status` has no internal timeout: it awaits `requester.response` on an
   aiocoap request built with `transport_tuning=Unreliable`. A device that
   accepts the request and never answers leaves the await pending.
3. `_async_reconnect` returns early while a reconnect is in flight:

   ```python
   if self._reconnect_task is not None and not self._reconnect_task.done():
       return
   ```

Once (1) hangs, the task is never `done()`, so (3) makes **every subsequent
reconnect a no-op, permanently** — including the ones the watchdog schedules.
The exponential backoff added in 2026.6.2 is right, and cannot be reached in
this state: reaching it needs the `except` branch, and the `except` branch needs
the await to return.

### The change

- bound `get_status` and `client.shutdown()` in the coordinator
  (`COAP_CALL_TIMEOUT`, `SHUTDOWN_TIMEOUT`) — on timeout the error lands in the
  existing `except`, so the backoff you already wrote becomes reachable rather
  than new;
- treat a reconnect older than `RECONNECT_TASK_MAX` as wedged and cancel it,
  instead of deferring to it for ever;
- the same bound on `_async_update_data`,
  `async_first_refresh_and_observe`, `async_set_control_values` and
  `async_shutdown`, which are the same shape.

⚠ `_async_observe_status` is **deliberately left unbounded** — it is the
long-lived push stream and is meant to block; the watchdog is what notices when
it goes quiet.

Happy to split this into "the two calls that stall" and "the rest of the same
shape" if you would rather review them separately.

### Tests

Four added to `tests/test_coordinator.py`, in the existing style:

- a device that accepts a read and never answers **fails** the reconnect rather
  than hanging it — asserting the log, the retry and the backoff;
- a client whose `shutdown()` hangs does not block the reconnect;
- a wedged reconnect is cancelled;
- a **young** reconnect is still left alone, so the duplicate guard is bounded
  rather than removed.

`375 passed` on the full suite, `ruff check` and `ruff format --check` clean.

Removing only the `wait_for` in `_do_reconnect` and keeping everything else
makes the first test fail with `TimeoutError`, so it fails for the reason it
claims rather than on a missing symbol.

### Environment

| | |
|---|---|
| integration | this branch, on `main` @ `ac3ec02` |
| Home Assistant | 2026.8.2, container |
| Python | 3.14.6 |
| `philips-airctrl` | 1.1.0 in production, 1.2.0 for the test run |
| devices | 2 × AMF family, wired LAN |

### One aside, in case it is unintended

`manifest.json` declares `issue_tracker` as this repository's `/issues`, and
Home Assistant's blocking-call warnings tell users to file bugs there — but
Issues are disabled on the repo, so that link 404s for everyone who follows it.
Hence a PR rather than an issue.
