### PR TITLE
fix(icons): Broken json syntax

### DIFF
--- a/custom_components/philips_airpurifier/icons.json
+++ b/custom_components/philips_airpurifier/icons.json
@@ -55,7 +55,7 @@
               "purification": "mdi:air-filter",
               "purification_humidification": "mdi:water-percent",
               "auto": "mdi:autorenew",
-              "allergen": mdi:flower-pollen-outline",
+              "allergen": "mdi:flower-pollen-outline",
               "sleep": "mdi:weather-night",
               "night": "mdi:weather-night",
               "turbo": "mdi:fan",


### PR DESCRIPTION
I had almost all icons broken on my Home Assistant instance and I've traced it down to this broken JSON file.

I'd appreciate if a patch/hotfix release was made for this so that other users don't experience this issue/get it fixed soon.